### PR TITLE
Fix pointers to value types (like *string)

### DIFF
--- a/swagger/reflect.go
+++ b/swagger/reflect.go
@@ -43,9 +43,7 @@ func inspect(t reflect.Type, jsonTag string) Property {
 		p.Ref = makeRef(name)
 
 	case reflect.Ptr:
-		p.GoType = t.Elem()
-		name := makeName(p.GoType)
-		p.Ref = makeRef(name)
+		return inspect(t.Elem(), jsonTag)
 
 	case reflect.Slice:
 		p.Type = "array"

--- a/swagger/reflect_test.go
+++ b/swagger/reflect_test.go
@@ -6,8 +6,9 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"fmt"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type Person struct {
@@ -23,6 +24,7 @@ type Pet struct {
 	IntArray    []int
 	String      string
 	StringArray []string
+	StringPtr   *string
 }
 
 type Empty struct {
@@ -40,7 +42,7 @@ func TestDefine(t *testing.T) {
 	obj, ok := v["swaggerPet"]
 	assert.True(t, ok)
 	assert.False(t, obj.IsArray)
-	assert.Equal(t, 8, len(obj.Properties))
+	assert.Equal(t, 9, len(obj.Properties))
 
 	content := map[string]Object{}
 	data, err := ioutil.ReadFile("testdata/pet.json")
@@ -71,21 +73,21 @@ func TestNotStructDefine(t *testing.T) {
 	obj, ok := v["int32"]
 	assert.True(t, ok)
 	assert.False(t, obj.IsArray)
-	assert.Equal(t, "integer", obj.Type )
+	assert.Equal(t, "integer", obj.Type)
 	assert.Equal(t, "int32", obj.Format)
 
 	v = define(uint64(1))
 	obj, ok = v["uint64"]
 	assert.True(t, ok)
 	assert.False(t, obj.IsArray)
-	assert.Equal(t, "integer", obj.Type )
+	assert.Equal(t, "integer", obj.Type)
 	assert.Equal(t, "int64", obj.Format)
 
 	v = define("")
 	obj, ok = v["string"]
 	assert.True(t, ok)
 	assert.False(t, obj.IsArray)
-	assert.Equal(t, "string", obj.Type )
+	assert.Equal(t, "string", obj.Type)
 	assert.Equal(t, "", obj.Format)
 
 	v = define(byte(1))
@@ -94,16 +96,16 @@ func TestNotStructDefine(t *testing.T) {
 		fmt.Printf("%v", v)
 	}
 	assert.False(t, obj.IsArray)
-	assert.Equal(t, "integer", obj.Type )
+	assert.Equal(t, "integer", obj.Type)
 	assert.Equal(t, "int32", obj.Format)
 
-	v = define([]byte{1,2})
+	v = define([]byte{1, 2})
 	obj, ok = v["uint8"]
 	if !assert.True(t, ok) {
 		fmt.Printf("%v", v)
 	}
 	assert.True(t, obj.IsArray)
-	assert.Equal(t, "integer", obj.Type )
+	assert.Equal(t, "integer", obj.Type)
 	assert.Equal(t, "int32", obj.Format)
 }
 

--- a/swagger/testdata/pet.json
+++ b/swagger/testdata/pet.json
@@ -27,6 +27,9 @@
       "String": {
         "type": "string"
       },
+      "StringPtr": {
+        "type": "string"
+      },
       "StringArray": {
         "type": "array",
         "items": {


### PR DESCRIPTION
When using a struct with *string elements makename() was returning .string, which was translated into ref "#/definitions/.string" which was not an available model reference and would throw errors in the swagger UI

To fix this when t.PkgPath() returns "" the name is used alone without the path. (this happens for built in types only) . This prevents filepath.Base(t.PkgPath()) from returning "."