### PR TITLE
Implement security definitions/requirements

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -120,6 +120,38 @@ func Endpoints(endpoints ...*swagger.Endpoint) Option {
 	}
 }
 
+// SecurityScheme creates a new security definition for the API.
+func SecurityScheme(name string, options ...swagger.SecuritySchemeOption) Option {
+	return func(builder *Builder) {
+		if builder.API.SecurityDefinitions == nil {
+			builder.API.SecurityDefinitions = map[string]swagger.SecurityScheme{}
+		}
+
+		scheme := swagger.SecurityScheme{}
+
+		for _, opt := range options {
+			opt(&scheme)
+		}
+
+		builder.API.SecurityDefinitions[name] = scheme
+	}
+}
+
+// Security sets a default security scheme for all endpoints in the API.
+func Security(scheme string, scopes ...string) Option {
+	return func(b *Builder) {
+		if b.API.Security == nil {
+			b.API.Security = &swagger.SecurityRequirement{}
+		}
+
+		if b.API.Security.Requirements == nil {
+			b.API.Security.Requirements = []map[string][]string{}
+		}
+
+		b.API.Security.Requirements = append(b.API.Security.Requirements, map[string][]string{scheme: scopes})
+	}
+}
+
 // New constructs a new api builder
 func New(options ...Option) *swagger.API {
 	b := &Builder{

--- a/builder_test.go
+++ b/builder_test.go
@@ -90,3 +90,22 @@ func TestHost(t *testing.T) {
 	)
 	assert.Equal(t, "blah", api.Host)
 }
+
+func TestSecurityScheme(t *testing.T) {
+	api := swag.New(
+		swag.SecurityScheme("basic", swagger.BasicSecurity()),
+		swag.SecurityScheme("apikey", swagger.APIKeySecurity("Authorization", "header")),
+	)
+	assert.Len(t, api.SecurityDefinitions, 2)
+	assert.Contains(t, api.SecurityDefinitions, "basic")
+	assert.Contains(t, api.SecurityDefinitions, "apikey")
+	assert.Equal(t, "header", api.SecurityDefinitions["apikey"].In)
+}
+
+func TestSecurity(t *testing.T) {
+	api := swag.New(
+		swag.Security("basic"),
+	)
+	assert.Len(t, api.Security.Requirements, 1)
+	assert.Contains(t, api.Security.Requirements[0], "basic")
+}

--- a/endpoint/builder.go
+++ b/endpoint/builder.go
@@ -116,6 +116,28 @@ func Tags(tags ...string) Option {
 	}
 }
 
+// Security allows a security scheme to be associated with the endpoint.
+func Security(scheme string, scopes ...string) Option {
+	return func(b *Builder) {
+		if b.Endpoint.Security == nil {
+			b.Endpoint.Security = &swagger.SecurityRequirement{}
+		}
+
+		if b.Endpoint.Security.Requirements == nil {
+			b.Endpoint.Security.Requirements = []map[string][]string{}
+		}
+
+		b.Endpoint.Security.Requirements = append(b.Endpoint.Security.Requirements, map[string][]string{scheme: scopes})
+	}
+}
+
+// NoSecurity explicitly sets the endpoint to have no security requirements.
+func NoSecurity() Option {
+	return func(b *Builder) {
+		b.Endpoint.Security = &swagger.SecurityRequirement{DisableSecurity: true}
+	}
+}
+
 // ResponseOption allows for additional configurations on responses like header information
 type ResponseOption func(response *swagger.Response)
 

--- a/examples/builtin/main.go
+++ b/examples/builtin/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/savaki/swag"
 	"github.com/savaki/swag/endpoint"
+	"github.com/savaki/swag/swagger"
 )
 
 func handle(w http.ResponseWriter, req *http.Request) {
@@ -33,15 +34,23 @@ func main() {
 		endpoint.Description("Additional information on adding a pet to the store"),
 		endpoint.Body(Pet{}, "Pet object that needs to be added to the store", true),
 		endpoint.Response(http.StatusOK, Pet{}, "Successfully added pet"),
+		endpoint.Security("petstore_auth", "read:pets", "write:pets"),
 	)
 	get := endpoint.New("get", "/pet/{petId}", "Find pet by ID",
 		endpoint.Handler(handle),
 		endpoint.Path("petId", "integer", "ID of pet to return", true),
 		endpoint.Response(http.StatusOK, Pet{}, "successful operation"),
+		endpoint.Security("petstore_auth", "read:pets"),
 	)
 
 	api := swag.New(
 		swag.Endpoints(post, get),
+		swag.Security("petstore_auth", "read:pets"),
+		swag.SecurityScheme("petstore_auth",
+			swagger.OAuth2Security("accessCode", "http://example.com/oauth/authorize", "http://example.com/oauth/token"),
+			swagger.OAuth2Scope("write:pets", "modify pets in your account"),
+			swagger.OAuth2Scope("read:pets", "read your pets"),
+		),
 	)
 
 	for path, endpoints := range api.Paths {

--- a/swagger/endpoint.go
+++ b/swagger/endpoint.go
@@ -1,5 +1,7 @@
 package swagger
 
+import "encoding/json"
+
 // Items represents items from the swagger doc
 type Items struct {
 	Type   string `json:"type,omitempty"`
@@ -53,4 +55,20 @@ type Endpoint struct {
 	Handler     interface{}         `json:"-"`
 	Parameters  []Parameter         `json:"parameters,omitempty"`
 	Responses   map[string]Response `json:"responses,omitempty"`
+
+	// swagger spec requires security to be an array of objects
+	Security *SecurityRequirement `json:"security,omitempty"`
+}
+
+type SecurityRequirement struct {
+	Requirements    []map[string][]string
+	DisableSecurity bool
+}
+
+func (s *SecurityRequirement) MarshalJSON() ([]byte, error) {
+	if s.DisableSecurity {
+		return []byte("[]"), nil
+	}
+
+	return json.Marshal(s.Requirements)
 }


### PR DESCRIPTION
1. Add security definitions to an API
1. Set default security requirements for the entire API
1. Set security requirements for a single endpoint
1. Mark an endpoint as not requiring security if the API has defaults set