### PR TITLE
[fix] Don't allow `null` for api.Tags

### DIFF
--- a/swagger/api.go
+++ b/swagger/api.go
@@ -232,7 +232,7 @@ type API struct {
 	Schemes             []string                  `json:"schemes,omitempty"`
 	Paths               map[string]*Endpoints     `json:"paths,omitempty"`
 	Definitions         map[string]Object         `json:"definitions,omitempty"`
-	Tags                []Tag                     `json:"tags"`
+	Tags                []Tag                     `json:"tags,omitempty"`
 	Host                string                    `json:"host"`
 	SecurityDefinitions map[string]SecurityScheme `json:"securityDefinitions,omitempty"`
 	Security            *SecurityRequirement      `json:"security,omitempty"`


### PR DESCRIPTION
Addresses an error when no API tags are defined, given they don't exist in the examples:

```
Swagger schema validation failed. 
  Expected type array but found type null at #/tags
 
JSON_OBJECT_VALIDATION_FAILED

Error: Swagger schema validation failed. 
  Expected type array but found type null at #/tags
 ```